### PR TITLE
Rework tool to just use a destination locality label

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/extraStatTags: destination_locality,source_locality
+        sidecar.istio.io/extraStatTags: destination_locality
 ```
 
 Add the following to your Istio Operator:
@@ -40,20 +40,12 @@ spec:
               metrics:
                 - name: request_bytes
                   dimensions:
-                    destination_locality: upstream_peer.labels['locality'].value
-                    source_locality: downstream_peer.labels['locality'].value
+                    destination_locality: downstream_peer.labels['locality'].value
             outboundSidecar:
               metrics:
                 - name: request_bytes
                   dimensions:
                     destination_locality: upstream_peer.labels['locality'].value
-                    source_locality: downstream_peer.labels['locality'].value
-            gateway:
-              metrics:
-                - name: request_bytes
-                  dimensions:
-                    destination_locality: upstream_peer.labels['locality'].value
-                    source_locality: downstream_peer.labels['locality'].value
 ```
 
 

--- a/cmd/analyze.go
+++ b/cmd/analyze.go
@@ -62,12 +62,12 @@ var analyzeCmd = &cobra.Command{
 			return err
 		}
 		// query prometheus for raw pod calls
-		podCalls, err := analyzerProm.GetPodCalls(duration)
+		localityCalls, err := analyzerProm.GetCalls(duration)
 		if err != nil {
 			return err
 		}
 		// transform raw pod calls to locality information
-		localityCalls, err := kubeClient.GetLocalityCalls(podCalls, cloud)
+		localityCalls, err = kubeClient.TransformLocalityCalls(localityCalls)
 		if err != nil {
 			return err
 		}

--- a/cmd/analyze.go
+++ b/cmd/analyze.go
@@ -32,7 +32,7 @@ var analyzeCmd = &cobra.Command{
 	Short: "List all the service links in the mesh",
 	Long:  ``,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		analyzerProm, err := pkg.NewAnalyzerProm(prometheusEndpoint)
+		analyzerProm, err := pkg.NewAnalyzerProm(prometheusEndpoint, cloud)
 		kubeClient := pkg.NewAnalyzerKube()
 		if err != nil {
 			return err
@@ -71,7 +71,6 @@ var analyzeCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		localityCalls[0].From = "us-west1-c"
 		// calculate egress given locality information
 		totalCost, err := cost.CalculateEgress(localityCalls)
 		if err != nil {

--- a/cmd/operator_setup.go
+++ b/cmd/operator_setup.go
@@ -1,0 +1,1 @@
+package cmd

--- a/cmd/webhook_setup.go
+++ b/cmd/webhook_setup.go
@@ -42,7 +42,7 @@ var costAnalyzerClusterRole = &v13.ClusterRole{
 		{
 			APIGroups: []string{"", "admissionregistration.k8s.io", "apps"},
 			Resources: []string{"mutatingwebhookconfigurations", "pods", "nodes", "deployments"},
-			Verbs:     []string{"get", "create", "patch", "list", "update"},
+			Verbs:     []string{"get", "create", "patch", "list ", "update"},
 		},
 	},
 }

--- a/pkg/cost.go
+++ b/pkg/cost.go
@@ -17,12 +17,6 @@ type CostAnalysis struct {
 
 type Pricing map[string]map[string]float64
 
-type PricingGCP struct {
-	InterZone      map[string]interface{} `json:"inter-zone-intra-region"`
-	InterRegion    map[string]interface{} `json:"inter-region-intra-continent"`
-	InterContinent map[string]interface{} `json:"inter-continent"`
-}
-
 func NewCostAnalysis(priceSheetLocation string) (*CostAnalysis, error) {
 	pricing := Pricing{}
 	var data []byte


### PR DESCRIPTION
This should make it so we don't have to fetch pods and the locality associated on the node info, we can just get the locality info directly from prometheus.