### PR TITLE
Watch & analyze multiple namespaces

### DIFF
--- a/cmd/analyze.go
+++ b/cmd/analyze.go
@@ -23,6 +23,7 @@ var (
 	promNs            string
 	analyzerNamespace string
 	targetNamespace   string
+	analyzeAll        bool
 	operatorName      string
 	operatorNamespace string
 	kubeconfig        string
@@ -121,6 +122,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&kubeconfig, "kubeconfig", defaultKube, "path to kubeconfig file")
 
 	destroyCmd.PersistentFlags().BoolVarP(&destroyOperator, "destroyOperator", "o", false, "if true, cost analyzer will destroy the istio operator config that it created")
+	webhookSetupCmd.PersistentFlags().BoolVarP(&analyzeAll, "analyzeAll", "a", false, "if true, cost analyzer will analyze all namespaces in the cluster")
 
 	rootCmd.AddCommand(analyzeCmd)
 	rootCmd.AddCommand(webhookSetupCmd)

--- a/mutating-webhook/cmd/mutating-webhook-ca/main.go
+++ b/mutating-webhook/cmd/mutating-webhook-ca/main.go
@@ -88,6 +88,11 @@ func main() {
 			FailurePolicy:           &fail,
 			SideEffects:             &sf,
 			AdmissionReviewVersions: []string{"v1"},
+			NamespaceSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"cost-analyzer-analysis-enabled": "true",
+				},
+			},
 		}},
 	}
 

--- a/pkg/kube.go
+++ b/pkg/kube.go
@@ -11,6 +11,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
@@ -193,6 +194,11 @@ func (k *KubeClient) CreateClusterRole(clusterRole *v13.ClusterRole) (*v13.Clust
 		return clusterRole, nil, true
 	}
 	return cr, err, false
+}
+
+func (k *KubeClient) LabelNamespace(ns, key, value string) error {
+	_, err := k.clientSet.CoreV1().Namespaces().Patch(context.TODO(), ns, types.MergePatchType, []byte(fmt.Sprintf(`{"metadata":{"labels":{"%v":"%v"}}}`, key, value)), metav1.PatchOptions{})
+	return err
 }
 
 func (k *KubeClient) Client() kubernetes.Interface {


### PR DESCRIPTION
For #19.

Instead of passing in a single namespace, we add the option for passing in a list of comma-separated namespaces to the tool, which propogates to the webhook, where all the deployments/pods are watched/labeled appropriately.